### PR TITLE
Add Dockerfile, minor tweaks to format of displayed stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile to clone the goresponsiveness repository
+# build the binary
+# make it ready to run
+
+# Build with: docker build -t goresp .
+
+# Run with: docker run goresp
+
+FROM golang:1.17.8-alpine3.15
+
+RUN mkdir /goresponsiveness
+ADD . /goresponsiveness
+WORKDIR /goresponsiveness
+
+RUN go mod download
+RUN go build -o networkQuality networkQuality.go 
+
+# `docker run` invokes the networkQuality binary that was just built
+ENTRYPOINT ["/goresponsiveness/networkQuality"]
+
+# These default parameters test against Apple's public servers
+# If you change any of these on the `docker run` command, you need to provide them all
+CMD ["-config","mensura.cdn-apple.com","-port","443","-path","/api/v1/gm/config"]
+

--- a/networkQuality.go
+++ b/networkQuality.go
@@ -418,6 +418,10 @@ func main() {
 		fmt.Printf("Test will end earlier than %v\n", timeoutAbsoluteTime)
 	}
 
+	// print the banner
+	dt := time.Now().UTC()
+	fmt.Printf("%s UTC Go Responsiveness to %s...\n", dt.Format("01-02-2006 15:04:05"),configHostPort)
+
 	if len(*profile) != 0 {
 		f, err := os.Create(*profile)
 		if err != nil {
@@ -612,24 +616,24 @@ func main() {
 			}
 		}
 	}
-
+	
 	fmt.Printf(
-		"Download: %f MBps (%f Mbps), using %d parallel connections.\n",
-		utilities.ToMBps(downloadSaturation.RateBps),
+		"Download: %7.3f Mbps (%7.3f MBps), using %d parallel connections.\n",
 		utilities.ToMbps(downloadSaturation.RateBps),
+		utilities.ToMBps(downloadSaturation.RateBps),
 		len(downloadSaturation.Lbcs),
 	)
 	fmt.Printf(
-		"Upload: %f MBps (%f Mbps), using %d parallel connections.\n",
-		utilities.ToMBps(uploadSaturation.RateBps),
+		"Upload:   %7.3f Mbps (%7.3f MBps), using %d parallel connections.\n",
 		utilities.ToMbps(uploadSaturation.RateBps),
+		utilities.ToMBps(uploadSaturation.RateBps),
 		len(uploadSaturation.Lbcs),
 	)
 
 	if totalRTTsCount != 0 {
 		rpm := float64(time.Minute.Seconds()) / (totalRTTTime / (float64(totalRTTsCount)))
 		fmt.Printf("Total RTTs measured: %d\n", totalRTTsCount)
-		fmt.Printf("RPM: %v\n", rpm)
+		fmt.Printf("RPM: %5.0f\n", rpm)
 	} else {
 		fmt.Printf("Error occurred calculating RPM -- no probe measurements received.\n")
 	}


### PR DESCRIPTION
This has a Dockerfile that builds and runs the networkQuality binary. I also tweaked up the format of the displayed statistics.

To build: `docker build -t goresp .`

To run: `docker run goresp`

It occasionally displays RPM values, but most of the time it gives the "Error occurred calculating RPM -- no probe measurements received." message

When it works, it displays:

```
√ goresponsiveness % docker run goresp
03-17-2022 14:09:52 UTC Go Responsiveness to mensura.cdn-apple.com:443...
Download:  26.405 Mbps (  3.301 MBps, 12 parallel connections)
Upload:    21.031 Mbps (  2.629 MBps, 20 parallel connections)
Total RTTs measured: 10
RPM:    76
```